### PR TITLE
degrade co to 3, try to fix memory leak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ autod: install
 	@node_modules/.bin/autod -w \
 		--prefix "~" \
 		--exclude public,views,coverage \
-		--dep mysql,bluebird \
+		--dep mysql \
 		--devdep should,supertest,should-http,mm,pedding,mocha,istanbul-harmony,sqlite3,co-mocha
 	@$(MAKE) install
 

--- a/package.json
+++ b/package.json
@@ -27,16 +27,15 @@
   },
   "license": "MIT",
   "dependencies": {
-    "bluebird": "~2.6.4",
     "bytes": "~1.0.0",
     "cfork": "~1.2.2",
-    "co": "~4.1.0",
+    "co": "~3.1.0",
     "copy-to": "~2.0.1",
     "debug": "~2.1.1",
     "fs-cnpm": "~1.1.0",
     "graceful": "~1.0.0",
     "humanize-ms": "~1.0.1",
-    "koa": "~0.14.0",
+    "koa": "~0.13.0",
     "koa-middlewares": "~2.1.0",
     "koa-mount": "~1.3.0",
     "mime-types": "~2.0.7",
@@ -46,7 +45,7 @@
     "only": "~0.0.2",
     "sequelize": "~2.0.0-rc7",
     "thunkify-wrap": "~1.0.4",
-    "urllib": "~2.2.1",
+    "urllib": "~2.2.2",
     "utility": "~1.2.1"
   },
   "devDependencies": {

--- a/sync/index.js
+++ b/sync/index.js
@@ -82,9 +82,12 @@ Object.keys(syncers).forEach(function (name) {
 
       yield sleep(syncInterval);
     }
-  }).catch(function (err) {
+  })(function (err) {
     throw err;
   });
+  // }).catch(function (err) {
+  //   throw err;
+  // });
 
 });
 

--- a/sync/mirrors.js
+++ b/sync/mirrors.js
@@ -40,7 +40,7 @@ proto.listdir = function* (fullname) {
   var url = this.disturl + fullname;
 
   var res = yield urllib.requestThunk(url, {
-    timeout: 60 * 1000,
+    timeout: 60000,
     dataType: 'json'
   });
   debug('listdir %s got %s, %j', url, res.status, res.headers);


### PR DESCRIPTION
Current mirrors syncer process momery stay on ~109MB

![image](https://cloud.githubusercontent.com/assets/156269/5822153/721b4986-a10c-11e4-8dbd-741d888a3860.png)

Need to run for a day. 
If there is no more memory increase, then we merge this.