### PR TITLE
添加 windows-build-tools 安装时使用镜像下载python安装包的使用用例

### DIFF
--- a/views/home.html
+++ b/views/home.html
@@ -77,6 +77,6 @@ SQLITE3_BINARY_SITE=<%= baseUrl %>/sqlite3 npm install sqlite3
 
 <h2><a href="https://github.com/felixrieseberg/windows-build-tools" target="_blank">windows-build-tools</a></h2>
 <textarea rows="1" style="width: 80%; overflow:hidden" readonly>
-set PYTHON_MIRROR=<%= baseUrl %>/python && npm install --global --production windows-build-tools
+set PYTHON_MIRROR=<%= baseUrl %>/python &amp;&amp; npm install --global --production windows-build-tools
 </textarea>
 

--- a/views/home.html
+++ b/views/home.html
@@ -77,6 +77,6 @@ SQLITE3_BINARY_SITE=<%= baseUrl %>/sqlite3 npm install sqlite3
 
 <h2><a href="https://github.com/felixrieseberg/windows-build-tools" target="_blank">windows-build-tools</a></h2>
 <textarea rows="1" style="width: 80%; overflow:hidden" readonly>
-set PYTHON_MIRROR=<%= baseUrl %>/python &amp;&amp; npm install --global --production windows-build-tools
+set "PYTHON_MIRROR=<%= baseUrl %>/python" &amp;&amp; npm install --global --production windows-build-tools
 </textarea>
 

--- a/views/home.html
+++ b/views/home.html
@@ -74,3 +74,9 @@ SASS_BINARY_SITE=<%= baseUrl %>/node-sass npm install node-sass
 <textarea rows="1" style="width: 80%; overflow:hidden" readonly>
 SQLITE3_BINARY_SITE=<%= baseUrl %>/sqlite3 npm install sqlite3
 </textarea>
+
+<h2><a href="https://github.com/felixrieseberg/windows-build-tools" target="_blank">windows-build-tools</a></h2>
+<textarea rows="1" style="width: 80%; overflow:hidden" readonly>
+set PYTHON_MIRROR=<%= baseUrl %>/python && npm install --global --production windows-build-tools
+</textarea>
+


### PR DESCRIPTION
windows-build-tools 可以方便的让node-gyp在Windows下正常工作，但是安装过程中，它需要去官网下载python安装包，国内可能下载一整夜也下载不完。而使用国内镜像，则快得多呢。

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cnpm/mirrors/121)
<!-- Reviewable:end -->
