### PR TITLE
Rename `electron-prebuilt` to `electron`

### DIFF
--- a/views/home.html
+++ b/views/home.html
@@ -50,7 +50,7 @@ npm install operadriver --operadriver_cdnurl=<%= baseUrl %>/operadriver
 
 <h2><a href="http://electron.atom.io" target="_blank">electron</a></h2>
 <textarea rows="1" style="width: 80%; overflow:hidden" readonly>
-ELECTRON_MIRROR=<%= baseUrl %>/electron/ npm install -g electron-prebuilt
+ELECTRON_MIRROR=<%= baseUrl %>/electron/ npm install -g electron
 </textarea>
 
 <h2><a href="https://github.com/vvo/selenium-standalone" target="_blank">selenium-standalone</a></h2>


### PR DESCRIPTION
`electron-prebuilt` 已经改名为 `electron`，所以应该修改示例中的名字：
参见：https://www.npmjs.com/package/electron#installation