### PR TITLE
fix a few errors

### DIFF
--- a/sync/syncer.js
+++ b/sync/syncer.js
@@ -251,7 +251,7 @@ proto.listdiff = function* (fullname, dirIndex) {
       continue;
     }
 
-    if (exist.type === 'file' && !this.check(exist, item)) {
+    if (exist.type === 'file' && item.size !== '-' && !this.check(exist, item)) {
       news.push(item);
       continue;
     }

--- a/sync/syncer.js
+++ b/sync/syncer.js
@@ -180,6 +180,10 @@ proto.syncFile = function* (info) {
 
     if (this.check) {
       var equivalent = this.check(checksums, info);
+      
+      if (info.remoteMetaUpdated === true) {
+        equivalent = true;
+      }
 
       if (!equivalent) {
         var err = new Error(fmt('Download %s file check not valid', downurl));
@@ -248,11 +252,13 @@ proto.listdiff = function* (fullname, dirIndex) {
 
     if (!exist || exist.date !== item.date) {
       news.push(item);
+      item.remoteMetaUpdated = true;
       continue;
     }
 
     if (exist.type === 'file' && item.size !== '-' && !this.check(exist, item)) {
       news.push(item);
+      item.remoteMetaUpdated = true;
       continue;
     }
 


### PR DESCRIPTION
fix sync error in cloneMode where size is '-' , make sync not stuck

```js
Error: Download http://npm.taobao.org/mirrors/node/latest/docs/sh_javascript.min.js file check not valid (sync node dist error)
    at MirrorsSyncer.proto.syncFile (/opt/meituan/mirrors/mirrors/sync/syncer.js:183:17)
    at next (native)
    at onFulfilled (/opt/meituan/mirrors/mirrors/node_modules/co/index.js:65:19)
    at tryCatcher (/opt/meituan/mirrors/mirrors/node_modules/bluebird/js/main/util.js:26:23)
    at Promise._settlePromiseFromHandler (/opt/meituan/mirrors/mirrors/node_modules/bluebird/js/main/promise.js:510:31)
    at Promise._settlePromiseAt (/opt/meituan/mirrors/mirrors/node_modules/bluebird/js/main/promise.js:584:18)
    at Promise._settlePromises (/opt/meituan/mirrors/mirrors/node_modules/bluebird/js/main/promise.js:700:14)
    at Async._drainQueue (/opt/meituan/mirrors/mirrors/node_modules/bluebird/js/main/async.js:123:16)
    at Async._drainQueues (/opt/meituan/mirrors/mirrors/node_modules/bluebird/js/main/async.js:133:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/opt/meituan/mirrors/mirrors/node_modules/bluebird/js/main/async.js:15:14)
    at processImmediate [as _immediateCallback] (timers.js:383:17)

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cnpm/mirrors/152)
<!-- Reviewable:end -->
