### PR TITLE
fix: add auth when retry, otherwise cause rate limit 60

### DIFF
--- a/sync/github.js
+++ b/sync/github.js
@@ -81,6 +81,7 @@ proto.listdir = function* (fullname) {
         timeout: 60000,
         dataType: 'json',
         gzip: true,
+        headers: { authorization: this.authorization },
         followRedirect: true,
         formatRedirectUrl: formatRedirectUrl,
       });


### PR DESCRIPTION
403重试的时候，由于没有authorization，触发了rate limit 60