### PR TITLE
fix: mysql duplicate entry error

### DIFF
--- a/models/dist_file.js
+++ b/models/dist_file.js
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS `dist_file` (
  `md5` varchar(40) COMMENT 'md5 hex value',
  `url` varchar(2048),
  PRIMARY KEY (`id`),
- UNIQUE KEY `dist_file_parent_name` (`parent`, `name`),
+ UNIQUE KEY `dist_file_category_parent_name` (`category`, `parent`, `name`),
  KEY `dist_file_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='dist file info';
  */


### PR DESCRIPTION
DDL and model are not consistent, using DDL to create tables and start syncing will cause a mysql error `Error 1062: Duplicate entry '/-index.json' for key 'dist_files.uidx_dist_file_parent_name'`.

This pull request modifies the DDL to create a multiple-column index that is consistent with the model.