### PR TITLE
feat: add electron nightly version support

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -227,6 +227,22 @@ var config = {
       retryOn403: true,
       cloneUrl: 'https://r.cnpmjs.org/-/binary',
     },
+    'electron-nightly': {
+      name: 'electron-nightly',
+      category: 'electron',
+      enable: true,
+      // interval: ms('5m'),
+      disturl: 'https://github.com/electron/nightlies/releases',
+      repo: 'electron/nightlies',
+      url: 'https://github.com/electron/nightlies',
+      description: ':electron: Build cross-platform desktop apps with JavaScript, HTML, and CSS https://electronjs.org',
+      max: 30, // sync the latest 10 releases
+      syncerClass: 'GithubWithVersion',
+      needFormatTagName: true,
+      // retry on 403 response
+      retryOn403: true,
+      cloneUrl: 'https://r.cnpmjs.org/-/binary',
+    },
     'electron-builder-binaries': {
       name: 'electron-builder-binaries',
       category: 'electron-builder-binaries',


### PR DESCRIPTION
> 这是一个待讨论可行性的 PR，如果一切 OK，我将补充剩下的代码

### 上下文

1. 目前 electron 具有 `nightly` 版本，但是此版本没有上传到 `npm` 上。例如: `v19.0.0-nightly.20220228`
2. nightly 主要用于测试/调试，主要是给 [electron-fiddle](https://github.com/electron/fiddle) 使用。
3. electron-fiddle 里是包括了electron 的所有版本，由用户自己去选择使用哪个版本进行测试/调试。因为有时去 bisect 时，越准确的区间，可以更加精准的判断问题。
4. 目前 electron 的维护版本是 4个大版本，所以不需要一直存储。超过 4 个大版本后可以进行删除。从 2020 年 5 月后，将降为 3个大版本，详情见: https://www.electronjs.org/blog/8-week-cadence#-will-electron-extend-the-number-of-supported-versions
5. 目前我这边是正在做 `electron-fiddle` / `electron/get` 面向中国区的优化工作。后期会在 `electron-fiddle` 里加入 taobao 源，以便方便中国区用户使用。而如果不支持的 nightly 的话，逻辑上可能就不是很完善。
6. 按照用户需求来说，不是很强，大部分是做 electron 开发时遇到问题了可能才会使用。这也是我刚刚说的可以删除 4 个大版本之前的文件。避免造成大量资源浪费。