### PR TITLE
feat: change node distUrl to release

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -128,7 +128,7 @@ var config = {
       category: 'node',
       enable: true,
       // interval: ms('5m'),
-      disturl: 'https://nodejs.org/dist',
+      disturl: 'https://nodejs.org/download/release',
       url: 'https://nodejs.org',
       description: 'is a platform built on Chrome\'s JavaScript runtime for easily building fast, scalable network applications.',
       syncDocument: true,


### PR DESCRIPTION
是否考虑把 /dist 改成 download/release，目前遇到一个问题是， dist 有部分镜像版本的缺失，例如 v16.x 的 latest 版本更新到了 v16.14.1，但是 dist 没有，导致镜像按照失败。

```
nvm install lts/gallium
nvm use lts/gallium
```

上面这行代码 `install` 过程会导致 404